### PR TITLE
Fix 7 bugs in configuration.py

### DIFF
--- a/sailpoint/configuration.py
+++ b/sailpoint/configuration.py
@@ -44,7 +44,7 @@ class Configuration:
         self.access_token = configurationParams.access_token if configurationParams and configurationParams.access_token else defaultConfiguration.access_token
         self.proxy = configurationParams.proxy if configurationParams and configurationParams.proxy else None
         self.proxy_headers = configurationParams.proxy_headers if configurationParams and configurationParams.proxy_headers else None
-        self.verify_ssl = configurationParams.verify_ssl if configurationParams and configurationParams.verify_ssl else True
+        self.verify_ssl = configurationParams.verify_ssl if configurationParams and configurationParams.verify_ssl is not None else True
 
         url = f"{self.token_url}"
         if self.access_token == None:
@@ -82,7 +82,6 @@ class Configuration:
         """Debug switch
         """
 
-        self.verify_ssl = True
         """SSL/TLS verification
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
@@ -134,19 +133,19 @@ class Configuration:
         """
 
     @classmethod
-    def get_configuration_params(self):
-        envConfiguration = self.get_environment_params()
+    def get_configuration_params(cls):
+        envConfiguration = cls.get_environment_params()
         if envConfiguration.base_url:
             return envConfiguration
 
-        localConfiguration = self.get_local_params()
+        localConfiguration = cls.get_local_params()
         if localConfiguration.base_url:
             return localConfiguration
 
         return ConfigurationParams()
 
     @classmethod
-    def get_environment_params(self) -> ConfigurationParams:
+    def get_environment_params(cls) -> ConfigurationParams:
         config = ConfigurationParams()
 
         config.base_url = (
@@ -162,26 +161,25 @@ class Configuration:
             if os.environ.get("SAIL_CLIENT_SECRET")
             else None
         )
-        config.token_url = str(config.base_url) + "/oauth/token"
+        config.token_url = (config.base_url + "/oauth/token") if config.base_url else None
 
         return config
 
     @classmethod
-    def get_local_params(self) -> ConfigurationParams:
+    def get_local_params(cls) -> ConfigurationParams:
         config = ConfigurationParams()
         if os.path.exists("./config.json"):
-            ("File is present")
             with open("./config.json") as file:
                 data = json.load(file)
-                config.base_url = data["BaseURL"]
-                config.client_id = data["ClientId"]
-                config.client_secret = data["ClientSecret"]
+                config.base_url = data.get("BaseURL")
+                config.client_id = data.get("ClientId")
+                config.client_secret = data.get("ClientSecret")
                 config.token_url = config.base_url + "/oauth/token"
         
         return config
 
     @classmethod
-    def get_access_token(self, url: str, client_id: str, client_secret: str, proxy: str, proxy_headers: dict, verify_ssl: bool) -> str:
+    def get_access_token(cls, url: str, client_id: str, client_secret: str, proxy: str, proxy_headers: dict, verify_ssl: bool) -> str:
 
         http = urllib3.PoolManager()
         pool_args = {}
@@ -218,7 +216,7 @@ class Configuration:
                     "There was an error while trying to fetch access token: "
                     + str(response.data)
                 )
-        except Exception as e:
+        except urllib3.exceptions.HTTPError as e:
             print("Unable to fetch access token. %s" % e)
 
     def auth_settings(self):
@@ -227,13 +225,6 @@ class Configuration:
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.access_token is not None:
-            auth["userAuth"] = {
-                "type": "oauth2",
-                "in": "header",
-                "key": "Authorization",
-                "value": "Bearer " + self.access_token,
-            }
         if self.access_token is not None:
             auth["userAuth"] = {
                 "type": "oauth2",


### PR DESCRIPTION
## Summary

Cross-SDK audit identified 7 bugs in `sailpoint/configuration.py`, ranging from critical (auth errors silently swallowed, SSL verification impossible to disable) to low (dead code, naming conventions).

## Bug Fixes

### High

**P1: `verify_ssl=False` impossible to set**
- [`sailpoint/configuration.py` L47](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L47): The check `configurationParams.verify_ssl if configurationParams and configurationParams.verify_ssl else True` treats `False` as falsy, falling through to `True`. SSL verification could never be disabled.
- [`sailpoint/configuration.py` L85](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L84): `self.verify_ssl = True` unconditionally overwrote the value set on L47.
- **Fix:** Changed to `is not None` check and removed the unconditional overwrite.

**P2: `get_access_token` swallows auth errors, returns `None`**
- [`sailpoint/configuration.py` L221-222](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L220): `except Exception as e: print(...)` caught the deliberately raised 401/error exceptions from lines 215-219, so authentication failures were silently swallowed and `None` was returned as the access token.
- **Fix:** Narrowed catch to `except urllib3.exceptions.HTTPError as e:` to only catch connection-level errors, letting auth errors propagate.

### Medium

**P3: `KeyError` on malformed `config.json`**
- [`sailpoint/configuration.py` L176-178](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L174): Direct dict access `data["BaseURL"]` throws `KeyError` if the key is missing from `config.json`.
- **Fix:** Changed to `data.get("BaseURL")` (same for `ClientId`, `ClientSecret`).

### Low

**P4: `@classmethod` methods use `self` instead of `cls`**
- [`sailpoint/configuration.py` L137, L149, L170, L184](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L137): Four `@classmethod`-decorated methods used `self` as their first parameter instead of `cls`. While Python doesn't enforce this, it's incorrect by convention and confusing.
- **Fix:** Changed `self` to `cls` in all four methods.

**P5: `str(None) + "/oauth/token"` produces `"None/oauth/token"`**
- [`sailpoint/configuration.py` L165](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L165): When `config.base_url` is `None`, `str(config.base_url) + "/oauth/token"` produces the string `"None/oauth/token"`.
- **Fix:** Guarded with `(config.base_url + "/oauth/token") if config.base_url else None`.

**P6: Bare string no-op `("File is present")`**
- [`sailpoint/configuration.py` L173](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L172): The expression `("File is present")` evaluates to a string but does nothing (not a function call, not assigned).
- **Fix:** Removed.

**P7: Duplicate `userAuth` block in `auth_settings()`**
- [`sailpoint/configuration.py` L237-243](https://github.com/sailpoint-oss/python-sdk/blob/fix/cross-sdk-bug-fixes/sailpoint/configuration.py#L230): The `userAuth` dict entry was set twice with identical code, the second overwriting the first.
- **Fix:** Removed the duplicate block.

## Verification

- `python -m py_compile sailpoint/configuration.py` passes clean
- `urllib3` import error when running full import is a pre-existing env issue (missing dependency), unrelated to changes

## Test plan

- [ ] Verify `Configuration(ConfigurationParams(verify_ssl=False))` correctly sets `verify_ssl` to `False`
- [ ] Verify auth errors (401) from `get_access_token` propagate instead of being swallowed
- [ ] Test with a malformed `config.json` (missing keys) to confirm no `KeyError`
- [ ] Verify config loading from environment variables still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)